### PR TITLE
Command preferences

### DIFF
--- a/AccuTermClient.py
+++ b/AccuTermClient.py
@@ -537,6 +537,7 @@ class AccuTermConv(sublime_plugin.TextCommand):
 #   console - Append the output to the console.
 class AccuTermExecute(sublime_plugin.TextCommand):
     def input(self, args):
+        if 'command' in args and args['command']: return None
         return ExecuteInputHandler(self.view)
 
     def run(self, edit, output_to='console', command=None): 

--- a/AccuTermClient.py
+++ b/AccuTermClient.py
@@ -541,6 +541,12 @@ class AccuTermExecute(sublime_plugin.TextCommand):
         return ExecuteInputHandler(self.view)
 
     def run(self, edit, output_to='console', command=None): 
+        # Expand the command with defined environment variables.
+        if command:
+            (mv_file, mv_item) = get_file_item(self.view)
+            command = command.replace('${FILE}', mv_file)
+            command = command.replace('${ITEM}', mv_item)
+
         self.command = command
         self.command_view = self.view
         if self.view.window() == None: output_to = 'console'

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -29,6 +29,15 @@
 					},
 				},
 				{
+					"caption": "Custom commands",
+					"command": "edit_settings", "args":
+					{
+						"base_file": "${packages}/AccuTermClient/AccuTermClient.sublime-commands",
+						"user_file": "${packages}/User/AccuTermClient.sublime-commands",
+						"default": "//AccuTermClient - User Commands\n[\n\t{\n\t\t\t// Name the command\n\t\t\t\"caption\": \"Term - Disable page breaks\",\n\t\t\t// Set the Sublime command to run\n\t\t\t\"command\": \"accu_term_execute\",\n\t\t\t// Set the command to run on the MV server and where to show the output (console, new, append, or replace).\n\t\t\t\"args\": { \"command\": \"TERM 150,0\", \"output_to\": \"console\"}\n\t},\n]"
+					}
+				},
+				{
 					"caption": "Key Bindings",
 					"command": "edit_settings", "args":
 					{


### PR DESCRIPTION
Added a menu item to easily create new Sublime commands. This allows the user to define custom commands using AccuTermClient commands like execute. The end result could be a MultiValue command in the Sublime command palette. The default command settings shows a command that will run "TERM 150,0" on the MV server.

This branch also adds command expansion for the AccuTermClient Execute. This enables creating commands like "CT ${FILE} ${ITEM} which will have the "${FILE}" & "${ITEM}" replaced by the currently active MV file and item. 