### PR TITLE
Use active window in project events

### DIFF
--- a/AccuTermClient.py
+++ b/AccuTermClient.py
@@ -819,7 +819,7 @@ class EventListener(sublime_plugin.EventListener):
                 if is_mv_syntax(view) and view.settings().get('AccuTermClient_lock_state', '') == 'locked': 
                     view.run_command('accu_term_release')
         elif command_name in ['open_recent_project_or_workspace', 'prompt_select_workspace', 'prompt_open_project_or_workspace']:
-            for view in window.views():
+            for view in sublime.active_window().views():
                 if is_mv_syntax(view) and view.settings().get('AccuTermClient_lock_state', '') in ['released', 'locked']: 
                     view.run_command('accu_term_lock')
 


### PR DESCRIPTION
Using the window that initiated the project event would not preform the locks on the newly opened project's files when using open_recent_project_or_workspace because a new window would be created.