### PR TITLE
Check sync with single connection

### DIFF
--- a/AccuTermClient.py
+++ b/AccuTermClient.py
@@ -845,9 +845,8 @@ class AccuTermClientLoadListener(sublime_plugin.ViewEventListener):
 
 
 # Event: plugin_loaded
-# Lock all MV items that were locked previously. Triggered by Sublime during startup.
+# Lock all MV items that were locked previously and check sync with MV server. Triggered by Sublime during startup.
 def plugin_loaded():
-
     def run():
         if threading.currentThread().getName() != 'MainThread': pythoncom.CoInitialize()
         mv_svr = connect()

--- a/AccuTermClient.py
+++ b/AccuTermClient.py
@@ -847,14 +847,18 @@ class AccuTermClientLoadListener(sublime_plugin.ViewEventListener):
 # Event: plugin_loaded
 # Lock all MV items that were locked previously. Triggered by Sublime during startup.
 def plugin_loaded():
-    mv_svr = connect()
-    if not mv_svr.IsConnected(): return 
-    for window in sublime.windows():
-        for view in window.views():
-            if not is_mv_syntax(view): continue
-            check_sync(view, mv_svr=mv_svr)
-            if get_view_lock_state(view) in ['locked', 'released']:
-                view.run_command('accu_term_lock')
+
+    def run():
+        if threading.currentThread().getName() != 'MainThread': pythoncom.CoInitialize()
+        mv_svr = connect()
+        if not mv_svr.IsConnected(): return 
+        for window in sublime.windows():
+            for view in window.views():
+                if not is_mv_syntax(view): continue
+                check_sync(view, mv_svr=mv_svr)
+                if get_view_lock_state(view) in ['locked', 'released']:
+                    view.run_command('accu_term_lock')
+    sublime.set_timeout_async( lambda: run(), 0)
 
 
 # Class: AccuTermRunCommand


### PR DESCRIPTION
Create the mv_svr object outside of the check sync function allows for skipping the connection() call in check_sync.