### PR TITLE
Expand compile command(s) for file & item

### DIFF
--- a/AccuTermClient.sublime-settings
+++ b/AccuTermClient.sublime-settings
@@ -3,7 +3,7 @@
 	"default_save_location": "%userprofile%\\code",
 	"default_file_extension": "bp",
 	"remove_file_extensions": ["bp", "qm", "d3", "proc", "jb", "mvbase"],
-	"compile_command": ["BASIC"],
+	"compile_command": ["BASIC ${FILE} ${ITEM}"],
 	"open_with_readu": true,
 	"result_line_regex": {
 		"QM": "([0-9]+):\\s()(.*)",


### PR DESCRIPTION
Command expansion allows for adding commands that don't need to reference the file and item. This is also consistent with the execute command.