### PR TITLE
Moved the locking & sync check

### DIFF
--- a/AccuTermClient.py
+++ b/AccuTermClient.py
@@ -826,7 +826,7 @@ class EventListener(sublime_plugin.EventListener):
 
 
 # Class: AccuTermClientLoadListener
-# When view is loaded it will be checked against the item on the MV server with <check_sync> and locking on the server will be updated as well.
+# When view is activated after loading it will be checked against the item on the MV server with <check_sync> and locking on the server will be updated as well.
 class AccuTermClientLoadListener(sublime_plugin.ViewEventListener):
     def __init__(self, view):
         self.view = view
@@ -838,10 +838,15 @@ class AccuTermClientLoadListener(sublime_plugin.ViewEventListener):
         return True
 
     def on_load(self):
-        # run functions as async, on_load_async wasn't firing for some reason.
+        self.check = True
+
+    def on_activated(self):
+        if not self.check: return 
+        self.check = False
         sublime.set_timeout_async( lambda: check_sync(self.view), 0)
         if get_view_lock_state(self.view) in ['locked', 'released']: 
             sublime.set_timeout_async( lambda: self.view.run_command('accu_term_lock'), 0)
+
 
 
 # Event: plugin_loaded


### PR DESCRIPTION
Altered the view event listener so the locking update and sync check only happen once the view is activated after loading. Bringing up the file switcher panel was causing the load event to fire which would then steal the view focus when locking was updated. Also the sync check would pop a dialog box if the file was out of sync before the item was selected from the panel. 

Now the view event listener sets a flag when the load event is fired that is required by the activate event to check sync & update locks. The activate event un-sets the flag so the functions will only be run once after loading.