### PR TITLE
Fix pywin32 dependency config

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,7 +1,7 @@
 {
     "windows": {
         ">=3000": [
-            "pyWin32"
+            "python-pywin32"
         ]
     },
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,21 +1,7 @@
 {
- "schema_version": "3.0.0",
- "packages": [],
- "dependencies": [
-        {
-            "name": "pyWin32",
-            "load_order": "01",
-            "description": "pywin32 for Sublime Text",
-            "author": "packagecontrol", 
-            "issues": "https://github.com/packagecontrol/sublime-pywin32/issues",
-            "releases": [
-                {
-                    "base": "https://github.com/packagecontrol/sublime-pywin32",
-                    "tags": true,
-                    "sublime_text": ">=3000",
-                    "platforms": ["windows"]
-                }
-            ]
-        }
-    ] 
+    "windows": {
+        ">=3000": [
+            "pyWin32"
+        ]
+    },
 }


### PR DESCRIPTION
The dependency.json was formatted wrong so package control wasn't processing it. This fix points to a different module that provides the same functionality. 