### PR TITLE
Change dispatch call with new object name

### DIFF
--- a/AccuTermClient.py
+++ b/AccuTermClient.py
@@ -39,7 +39,7 @@ def log_output(window, output_text, panel_name='AccuTermClient'):
 # Returns:
 #   object - AccuTerm Server object.
 def connect(panel_name='AccuTermClient'):
-    mv_svr = Dispatch('atMVSvr71.Server')
+    mv_svr = Dispatch('atPickServer.Server')
     if mv_svr.Connect():
         # log_output(sublime.active_window(), 'Connected', panel_name) # Ideally the connecct would be passed the window but this is intended for debugging only.
         pass


### PR DESCRIPTION
In AccuTerm8 the call to Dispatch('atMVSvr71.Server') is no longer valid. The specific version call would be 'atMVSvr80.Server' but atPickServer.Server is valid as well and will likely be supported in future releases.